### PR TITLE
add clean flag in stop cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Release Notes
 
+- [#49](https://github.com/lodastack/agent/pull/49): support clean data dir in stop command
+
 ### Bugfixes
 
 - [#48](https://github.com/lodastack/agent/pull/48): Update process proc CPU

--- a/agent/common/var.go
+++ b/agent/common/var.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	EXCEPTION_NS = "collect.exception.monitor.loda"
+	EXCEPTION_NS = "exception.monitor.loda"
 	HOST_SUFFIX  = ""
 )
 

--- a/command/stop.go
+++ b/command/stop.go
@@ -18,10 +18,20 @@ var CmdStop = cli.Command{
 	Usage:       "关闭客户端",
 	Description: "关闭Agent客户端",
 	Action:      runStop,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "m",
+			Value: "normal",
+			Usage: "stop agent mode",
+		},
+	},
 }
 
 func runStop(c *cli.Context) {
 	stopAgent()
+	if c.String("m") == "clean" {
+		cleanData()
+	}
 }
 
 func stopAgent() {
@@ -54,4 +64,13 @@ func stopAgent() {
 		fmt.Printf("send signal to process successfully and remove pid error: %s ", err)
 	}
 	fmt.Printf("send signal to process successfully ")
+}
+
+func cleanData() {
+	// TODO:stop don't know the data dir, data dir is a var, need to use signal to pass remove cmd.
+	if err := os.RemoveAll("/usr/local/agent-plugins"); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Println("clean agent data finish")
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass


`./agent stop -m clean` to clean agent data dir.
