### PR TITLE
provide random seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugfixes
 
+- [#61](https://github.com/lodastack/agent/pull/61): provide random seed
+
 ## v0.2.1 [2017-05-19]
 
 ### Release Notes

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"math/rand"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/lodastack/agent/command"
 	"github.com/lodastack/agent/config"
@@ -39,6 +41,8 @@ func init() {
 }
 
 func main() {
+	rand.Seed(int64(time.Now().Nanosecond()))
+
 	if runtime.GOOS == "windows" {
 		command.WindowsStart()
 		return


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

 If Seed is not called, the generator behaves as if seeded by Seed(1). Seed values that have the same remainder when divided by 2^31-1 generate the same pseudo-random sequence.

@lodastack/developers
