### PR TITLE
NTP server configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Release Notes
 
 - [#65](https://github.com/lodastack/agent/pull/65): support collect disk usage blocks metrices
+- [#66](https://github.com/lodastack/agent/pull/66): [config breaking change] NTP server configurable
 
 ### Bugfixes
 

--- a/agent/common/config.go
+++ b/agent/common/config.go
@@ -3,6 +3,7 @@ package common
 type AgentConfig struct {
 	Listen       string   `toml:"listen"`
 	IfacePrefix  []string `toml:"ifaceprefix"`
+	NTPServer    string   `toml:"ntpserver"`
 	PluginsDir   string   `toml:"pluginsdir"`
 	PluginsUser  string   `toml:"pluginsuser"`
 	RegistryAddr string   `toml:registryaddr"`
@@ -15,6 +16,9 @@ func InitCollectConfig(config *AgentConfig) {
 	// Default use root exec plugins
 	if config.PluginsUser == "" {
 		config.PluginsUser = "root"
+	}
+	if config.NTPServer == "" {
+		config.NTPServer = "133.100.11.8"
 	}
 	Conf = config
 }

--- a/agent/sysinfo/time.go
+++ b/agent/sysinfo/time.go
@@ -117,7 +117,7 @@ type Response struct {
 func TimeMetrics() (L []*common.Metric) {
 	times := 3
 	for i := 1; i <= times; i++ {
-		res, err := Query(ntpserver, ntpversion)
+		res, err := Query(common.Conf.NTPServer, ntpversion)
 		if err != nil && i == times {
 			log.Debugf("query time from NTP server failed: %s", err)
 			return

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -1,6 +1,7 @@
 [agent]
 	listen = "0.0.0.0:1232"
 	ifaceprefix = [ "eth" ]
+	ntpserver = ""
 	registryaddr = "https://registry.test.com"
 	pluginsdir = "/usr/local/agent-plugins"
 	pluginsuser = "user"


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass


@lodastack/developers

add `ntpserver` in config file, default value is `133.100.11.8` 