### PR TITLE
sysinfo: fix disk io await negative value issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bugfixes
 
-
+- [#92](https://github.com/lodastack/agent/pull/92): fix disk io await negative value issue
 
 ## v0.2.8 [2018-01-04]
 

--- a/agent/sysinfo/diskstats.go
+++ b/agent/sysinfo/diskstats.go
@@ -132,10 +132,13 @@ func IOStatsMetrics() (L []*common.Metric) {
 		ruse := IODelta(device, IOMsecRead)
 		wuse := IODelta(device, IOMsecWrite)
 		use := IODelta(device, IOMsecTotal)
-		n_io := rio + wio
+		nio := rio + wio
 		await := 0.0
-		if n_io != 0 {
-			await = common.SetPrecision(float64(ruse+wuse)/float64(n_io), 2)
+		if nio != 0 {
+			await = common.SetPrecision(float64(ruse+wuse)/float64(nio), 2)
+		}
+		if await < 0 {
+			await = 0.0
 		}
 
 		duration := IODelta(device, TS)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass


@lodastack/developers
